### PR TITLE
Updated size of Map.dbc structure.

### DIFF
--- a/DBCTemplate.bt
+++ b/DBCTemplate.bt
@@ -551,7 +551,7 @@ typedef struct  {
   uint32_t m_parentMapID;
   uint32_t m_cosmeticParentMapID;
   uint32_t m_timeOffset;
-} MapRec<size=88, read=readMapRec>;
+} MapRec<size=264, read=readMapRec>;
 
 string readMapRec(MapRec&rec)
 {


### PR DESCRIPTION
I do not know why someone decided it was 88. It is actually 264.
